### PR TITLE
new: redirect not founds to /repo

### DIFF
--- a/pkg/server/staticreg/staticreg.go
+++ b/pkg/server/staticreg/staticreg.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"path"
 	"sort"
 	"strings"
 	"time"
@@ -198,11 +199,19 @@ func (s *StaticregServer) InternalServerErrorHandler(c *gin.Context) {
 }
 
 func (s *StaticregServer) NoRouteHandler(c *gin.Context) {
-	baseData := s.dataFiller.BaseData()
-
-	err := templates.Render404(c.Writer, baseData)
-	if err != nil {
-		c.Error(err)
-		return
+	originalPath := c.Request.URL.Path
+	if strings.HasPrefix(originalPath, "/repo/") {
+		baseData := s.dataFiller.BaseData()
+		err := templates.Render404(c.Writer, baseData)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
 	}
+
+	repoPath := path.Join("/repo", originalPath)
+	if c.Request.URL.RawQuery != "" {
+		repoPath += "?" + c.Request.URL.RawQuery
+	}
+	c.Redirect(http.StatusMovedPermanently, repoPath)
 }


### PR DESCRIPTION
The docker pull command for an image might be something like

```bash
docker pull community.wave.seqera.io/community/library:8c9ee6a71b4214f5
```

If a user just wants to just view that image now they don't find the staticreg ui at https://community.wave.seqera.io/community/library but only at https://community.wave.seqera.io/repo/community/library 

This patch adjusts that by adding a redirect.

I think it's better to keep the `/repo` prefix to avoid issues in case we want to add more features.