### PR TITLE
Implement hierarchical repository view

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -34,6 +34,7 @@ type Server struct {
 
 type ServerImpl interface {
 	RepositoriesListHandler(ctx *gin.Context)
+	HierarchicalBrowseHandler(ctx *gin.Context)
 	RepositoryHandler(ctx *gin.Context)
 	NotFoundHandler(ctx *gin.Context)
 	NoRouteHandler(ctx *gin.Context)
@@ -84,6 +85,7 @@ func New(
 	htmlRoutes := r.Group("/")
 	{
 		r.GET("/", cache.CacheByRequestURI(store, cacheDuration), serverImpl.RepositoriesListHandler)
+		r.GET("/browse/*path", cache.CacheByRequestURI(store, cacheDuration), serverImpl.HierarchicalBrowseHandler)
 		r.GET("/repo/*slug", cache.CacheByRequestURI(store, cacheDuration), serverImpl.RepositoryHandler)
 	}
 	htmlRoutes.Use(htmlContentTypeMiddleware)

--- a/pkg/server/staticreg/staticreg.go
+++ b/pkg/server/staticreg/staticreg.go
@@ -54,8 +54,13 @@ func New(
 }
 
 func (s *StaticregServer) RepositoriesListHandler(c *gin.Context) {
-	repositoriesData := []templates.IndexRepositoryData{}
+	s.HierarchicalBrowseHandler(c)
+}
+
+func (s *StaticregServer) HierarchicalBrowseHandler(c *gin.Context) {
 	baseData := s.dataFiller.BaseData()
+	currentPath := strings.TrimPrefix(c.Param("path"), "/")
+	currentPath = strings.TrimSuffix(currentPath, "/")
 
 	repos, err := s.regClient.RepoList(c)
 	if err != nil {
@@ -63,32 +68,16 @@ func (s *StaticregServer) RepositoriesListHandler(c *gin.Context) {
 		return
 	}
 
-	sortedRepos := make([]string, len(repos))
-	i := 0
-	for k := range repos {
-		sortedRepos[i] = k
-		i++
-	}
-	sort.Strings(sortedRepos)
-
-	for _, rk := range sortedRepos {
-		repo, ok := repos[rk]
-		if !ok {
-			continue
-		}
-		idata := templates.IndexRepositoryData{
-			BaseData:       baseData,
-			RepositoryName: repo.Name,
-			PullReference:  repo.PullReference,
-			LastUpdatedAt:  repo.LastUpdatedAt.Format(time.RFC3339),
-		}
-		repositoriesData = append(repositoriesData, idata)
-	}
+	hierarchy, repositories := s.buildHierarchy(repos, currentPath, baseData)
+	breadcrumbs := s.buildBreadcrumbs(currentPath)
 
 	var buf bytes.Buffer
 	err = templates.RenderIndex(&buf, templates.IndexData{
 		BaseData:     baseData,
-		Repositories: repositoriesData,
+		CurrentPath:  currentPath,
+		Breadcrumbs:  breadcrumbs,
+		Nodes:        hierarchy,
+		Repositories: repositories,
 	})
 
 	if err != nil {
@@ -102,6 +91,84 @@ func (s *StaticregServer) RepositoriesListHandler(c *gin.Context) {
 		c.Error(err)
 		return
 	}
+}
+
+func (s *StaticregServer) buildHierarchy(repos map[string]registry.RepoData, currentPath string, baseData templates.BaseData) ([]*templates.HierarchicalNode, []templates.IndexRepositoryData) {
+	folders := make(map[string]*templates.HierarchicalNode)
+	var repositories []templates.IndexRepositoryData
+
+	sortedRepos := make([]string, 0, len(repos))
+	for k := range repos {
+		sortedRepos = append(sortedRepos, k)
+	}
+	sort.Strings(sortedRepos)
+
+	for _, repoName := range sortedRepos {
+		repo := repos[repoName]
+		parts := strings.Split(repoName, "/")
+
+		if currentPath == "" {
+			if len(parts) == 1 {
+				repositories = append(repositories, templates.IndexRepositoryData{
+					BaseData:       baseData,
+					RepositoryName: repo.Name,
+					PullReference:  repo.PullReference,
+					LastUpdatedAt:  repo.LastUpdatedAt.Format(time.RFC3339),
+				})
+			} else {
+				firstPart := parts[0]
+				if folders[firstPart] == nil {
+					folders[firstPart] = &templates.HierarchicalNode{
+						Name:     firstPart,
+						IsFolder: true,
+					}
+				}
+			}
+		} else {
+			pathParts := strings.Split(currentPath, "/")
+			if len(parts) > len(pathParts) && strings.HasPrefix(repoName, currentPath+"/") {
+				remainingPath := strings.TrimPrefix(repoName, currentPath+"/")
+				remainingParts := strings.Split(remainingPath, "/")
+
+				if len(remainingParts) == 1 {
+					repositories = append(repositories, templates.IndexRepositoryData{
+						BaseData:       baseData,
+						RepositoryName: repo.Name,
+						PullReference:  repo.PullReference,
+						LastUpdatedAt:  repo.LastUpdatedAt.Format(time.RFC3339),
+					})
+				} else {
+					firstPart := remainingParts[0]
+					if folders[firstPart] == nil {
+						folders[firstPart] = &templates.HierarchicalNode{
+							Name:     firstPart,
+							IsFolder: true,
+						}
+					}
+				}
+			}
+		}
+	}
+
+	var nodes []*templates.HierarchicalNode
+	for _, folder := range folders {
+		nodes = append(nodes, folder)
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].Name < nodes[j].Name
+	})
+
+	return nodes, repositories
+}
+
+func (s *StaticregServer) buildBreadcrumbs(currentPath string) []string {
+	if currentPath == "" {
+		return []string{}
+	}
+	parts := strings.Split(currentPath, "/")
+	breadcrumbs := make([]string, len(parts))
+	copy(breadcrumbs, parts)
+	return breadcrumbs
 }
 
 func (s *StaticregServer) RepositoryHandler(c *gin.Context) {

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -35,8 +35,11 @@ func init() {
 		"500":        "500.html",
 	}
 	htmlTemplates = make(map[string]*template.Template, len(templateDefs))
+	funcMap := template.FuncMap{
+		"subtract": func(a, b int) int { return a - b },
+	}
 	for tplName, templateDef := range templateDefs {
-		tpl, err := template.New(templateDef).ParseFS(templates, path.Join("tmpl", templateDef))
+		tpl, err := template.New(templateDef).Funcs(funcMap).ParseFS(templates, path.Join("tmpl", templateDef))
 		if err != nil {
 			panic(err)
 		}
@@ -50,8 +53,18 @@ type BaseData struct {
 	LastUpdated  string
 }
 
+type HierarchicalNode struct {
+	Name         string
+	IsFolder     bool
+	Children     []*HierarchicalNode
+	Repositories []IndexRepositoryData
+}
+
 type IndexData struct {
 	BaseData
+	CurrentPath  string
+	Breadcrumbs  []string
+	Nodes        []*HierarchicalNode
 	Repositories []IndexRepositoryData
 }
 

--- a/pkg/templates/tmpl/index.html
+++ b/pkg/templates/tmpl/index.html
@@ -17,6 +17,28 @@
         </header>
         <main class="container mx-auto">
             <div class="mx-auto px-4 py-6 sm:px-6 lg:px-8">
+                {{if .Breadcrumbs}}
+                <nav class="flex mb-4" aria-label="Breadcrumb">
+                    <ol class="inline-flex items-center space-x-1 md:space-x-3">
+                        <li class="inline-flex items-center">
+                            <a href="{{.AbsoluteDir}}" class="text-blue-600 hover:text-blue-800">🏠</a>
+                        </li>
+                        {{range $index, $crumb := .Breadcrumbs}}
+                        <li>
+                            <div class="flex items-center">
+                                <span class="text-gray-400 mx-2">/</span>
+                                {{if eq $index (subtract (len $.Breadcrumbs) 1)}}
+                                <span class="text-gray-500">{{$crumb}}</span>
+                                {{else}}
+                                <a href="{{$.AbsoluteDir}}browse/{{range $i, $c := $.Breadcrumbs}}{{if le $i $index}}{{if $i}}/{{end}}{{$c}}{{end}}{{end}}" class="text-blue-600 hover:text-blue-800">{{$crumb}}</a>
+                                {{end}}
+                            </div>
+                        </li>
+                        {{end}}
+                    </ol>
+                </nav>
+                {{end}}
+
                 <input type="text" id="searchInput" onkeyup="searchImages()" placeholder="Search for images.."
                     class="w-full p-2 mb-4 border border-gray-300 focus:outline-none focus:ring focus:ring-blue-400">
                 <div class="overflow-x-auto">
@@ -29,18 +51,30 @@
                             </tr>
                         </thead>
                         <tbody class="divide-y divide-gray-300">
+                            {{range .Nodes}}
+                            <tr>
+                                <td class="p-2 text-left break-words whitespace-pre-line">
+                                    <a class="text-blue-600 hover:text-blue-800 visited:text-purple-600" 
+                                       href="{{$.AbsoluteDir}}browse/{{if $.CurrentPath}}{{$.CurrentPath}}/{{end}}{{.Name}}">
+                                        📁 {{.Name}}
+                                    </a>
+                                </td>
+                                <td class="p-2 text-xs text-left min-w-lg">-</td>
+                                <td class="p-2 text-xs text-left">-</td>
+                            </tr>
+                            {{end}}
                             {{range .Repositories}}
                             <tr>
-                                <td class="p-2 text-left  break-words whitespace-pre-line"><a
-                                        class="text-blue-600 hover:text-blue-800 visited:text-purple-600"
-                                        href="{{$.AbsoluteDir}}repo/{{.RepositoryName}}">{{.RepositoryName}}</a>
+                                <td class="p-2 text-left break-words whitespace-pre-line">
+                                    <a class="text-blue-600 hover:text-blue-800 visited:text-purple-600"
+                                       href="{{$.AbsoluteDir}}repo/{{.RepositoryName}}">{{.RepositoryName}}</a>
                                 </td>
-                                <td class="p-2 text-xs text-left min-w-lg">{{.LastUpdatedAt}}
+                                <td class="p-2 text-xs text-left min-w-lg">{{.LastUpdatedAt}}</td>
+                                <td class="p-2 font-mono text-left whitespace-nowrap">
+                                    <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">
+                                        docker pull {{.PullReference}}
+                                    </span>
                                 </td>
-
-                                <td class="p-2 font-mono text-left whitespace-nowrap"><span
-                                        class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">docker
-                                        pull {{.PullReference}}</span></td>
                             </tr>
                             {{end}}
                         </tbody>


### PR DESCRIPTION
## Summary

This PR transforms the flat repository listing into a navigable hierarchical folder structure, addressing the need to organize repositories with common path prefixes in a more intuitive way.

### Changes Made

- **Data structures**: Added `HierarchicalNode` for tree representation and enhanced `IndexData` with hierarchical fields
- **Backend logic**: Implemented `buildHierarchy()` function to group repositories by path segments and create folder structure
- **Routing**: Added `/browse/*path` route for hierarchical navigation while maintaining existing `/repo/*` URLs
- **Frontend**: Updated template with breadcrumb navigation, folder icons, and hierarchical display

### Navigation Flow

**Before**: All repositories displayed in flat list
```
nextflow/foo
nextflow/plugin/nf-amazon  
nextflow/plugin/nf-azure
nextflow/plugin/nf-boost
```

**After**: Hierarchical navigation with folders
- Root (`/`) → Shows "nextflow" folder
- Browse (`/browse/nextflow`) → Shows "foo" repository and "plugin" folder
- Deep browse (`/browse/nextflow/plugin`) → Shows "nf-amazon", "nf-azure", "nf-boost" repositories

### Benefits

- **Improved organization**: Groups related repositories under common path segments
- **Better navigation**: Users can drill down through folder structure
- **Backward compatibility**: Existing repository URLs continue to work unchanged
- **Visual clarity**: Folder icons distinguish directories from repositories

🤖 Generated with [Claude Code](https://claude.ai/code)