### PR TITLE
feat: open wave.seqera.io links in new browser windows

### DIFF
--- a/pkg/registry/registry/registry.go
+++ b/pkg/registry/registry/registry.go
@@ -114,7 +114,7 @@ func (c *Registry) ImageInfo(ctx context.Context, image string, tag string) (reg
 		}
 	}
 	inspectIcon, _ := icons.ReadFile("img/inspect-icon.svg")
-	inspectUrl := template.HTML(fmt.Sprintf("<a href=%s/view/inspect?image=%s>%s</a>", waveServerUrl, ref, inspectIcon))
+	inspectUrl := template.HTML(fmt.Sprintf("<a href=%s/view/inspect?image=%s target=\"_blank\" rel=\"noopener noreferrer\">%s</a>", waveServerUrl, ref, inspectIcon))
 
 	scanUrl := template.HTML(strings.Join(scanUrls, ""))
 

--- a/pkg/static/assets/js/app.js
+++ b/pkg/static/assets/js/app.js
@@ -109,7 +109,7 @@
         })
             .then(response => {
                 if (response.redirected) {
-                    window.location.href = response.url;
+                    window.open(response.url, '_blank', 'noopener,noreferrer');
                 } else {
                     return response.json();
                 }


### PR DESCRIPTION
## Summary
- Modified inspect links to include `target="_blank"` attribute for opening in new windows
- Updated JavaScript redirect behavior for scan links to use `window.open()` instead of replacing current page
- Added security attributes (`rel="noopener noreferrer"`) to prevent potential security issues

## Test plan
- [ ] Verify inspect links open in new browser windows when clicked
- [ ] Verify scan links open security scan results in new browser windows
- [ ] Confirm security attributes are properly applied to prevent referrer leaking

🤖 Generated with [Claude Code](https://claude.ai/code)