### PR TITLE
Add HTTP Security Headers

### DIFF
--- a/pkg/server/security_headers_test.go
+++ b/pkg/server/security_headers_test.go
@@ -1,0 +1,264 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestSecurityHeadersMiddleware(t *testing.T) {
+	// Set Gin to test mode
+	gin.SetMode(gin.TestMode)
+
+	// Create a test router with the security headers middleware
+	router := gin.New()
+	router.Use(securityHeadersMiddleware())
+
+	// Add a simple test endpoint
+	router.GET("/test", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	// Create a test request
+	req, err := http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create test request: %v", err)
+	}
+
+	// Create a response recorder
+	w := httptest.NewRecorder()
+
+	// Perform the request
+	router.ServeHTTP(w, req)
+
+	// Verify response status
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
+	}
+
+	// Test all security headers
+	tests := []struct {
+		name          string
+		headerName    string
+		expectedValue string
+	}{
+		{
+			name:          "Strict-Transport-Security header",
+			headerName:    "Strict-Transport-Security",
+			expectedValue: "max-age=31536000; includeSubDomains",
+		},
+		{
+			name:          "X-Frame-Options header",
+			headerName:    "X-Frame-Options",
+			expectedValue: "DENY",
+		},
+		{
+			name:          "X-Content-Type-Options header",
+			headerName:    "X-Content-Type-Options",
+			expectedValue: "nosniff",
+		},
+		{
+			name:          "Content-Security-Policy header",
+			headerName:    "Content-Security-Policy",
+			expectedValue: "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: https:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';",
+		},
+		{
+			name:          "Referrer-Policy header",
+			headerName:    "Referrer-Policy",
+			expectedValue: "strict-origin-when-cross-origin",
+		},
+		{
+			name:          "Permissions-Policy header",
+			headerName:    "Permissions-Policy",
+			expectedValue: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualValue := w.Header().Get(tt.headerName)
+			if actualValue != tt.expectedValue {
+				t.Errorf("Expected %s header to be %q, got %q", tt.headerName, tt.expectedValue, actualValue)
+			}
+		})
+	}
+}
+
+func TestSecurityHeadersMiddleware_MultipleRequests(t *testing.T) {
+	// Set Gin to test mode
+	gin.SetMode(gin.TestMode)
+
+	// Create a test router with the security headers middleware
+	router := gin.New()
+	router.Use(securityHeadersMiddleware())
+
+	router.GET("/endpoint1", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "endpoint1"})
+	})
+
+	router.POST("/endpoint2", func(c *gin.Context) {
+		c.JSON(http.StatusCreated, gin.H{"message": "endpoint2"})
+	})
+
+	endpoints := []struct {
+		method string
+		path   string
+		status int
+	}{
+		{"GET", "/endpoint1", http.StatusOK},
+		{"POST", "/endpoint2", http.StatusCreated},
+	}
+
+	for _, endpoint := range endpoints {
+		t.Run(endpoint.method+"_"+endpoint.path, func(t *testing.T) {
+			req, err := http.NewRequest(endpoint.method, endpoint.path, nil)
+			if err != nil {
+				t.Fatalf("Failed to create test request: %v", err)
+			}
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != endpoint.status {
+				t.Errorf("Expected status code %d, got %d", endpoint.status, w.Code)
+			}
+
+			// Verify critical security headers are present
+			criticalHeaders := []string{
+				"Strict-Transport-Security",
+				"X-Frame-Options",
+				"X-Content-Type-Options",
+				"Content-Security-Policy",
+			}
+
+			for _, header := range criticalHeaders {
+				if w.Header().Get(header) == "" {
+					t.Errorf("Expected %s header to be set, but it was empty", header)
+				}
+			}
+		})
+	}
+}
+
+func TestSecurityHeadersMiddleware_WithOtherMiddleware(t *testing.T) {
+	// Set Gin to test mode
+	gin.SetMode(gin.TestMode)
+
+	// Create a test router with multiple middleware
+	router := gin.New()
+
+	// Add custom middleware that sets a custom header
+	router.Use(func(c *gin.Context) {
+		c.Header("X-Custom-Header", "custom-value")
+		c.Next()
+	})
+
+	// Add security headers middleware
+	router.Use(securityHeadersMiddleware())
+
+	router.GET("/test", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	req, err := http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create test request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Verify both custom and security headers are present
+	if w.Header().Get("X-Custom-Header") != "custom-value" {
+		t.Error("Custom header from other middleware was not set")
+	}
+
+	if w.Header().Get("Strict-Transport-Security") == "" {
+		t.Error("Security headers were not set when combined with other middleware")
+	}
+}
+
+func TestSecurityHeadersMiddleware_HSTS_Format(t *testing.T) {
+	// Set Gin to test mode
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(securityHeadersMiddleware())
+	router.GET("/test", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	req, _ := http.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	hstsHeader := w.Header().Get("Strict-Transport-Security")
+
+	// Verify HSTS includes max-age
+	if hstsHeader == "" {
+		t.Fatal("HSTS header is not set")
+	}
+
+	// Verify it includes both max-age and includeSubDomains
+	expectedComponents := []string{"max-age=31536000", "includeSubDomains"}
+	for _, component := range expectedComponents {
+		found := false
+		if containsString(hstsHeader, component) {
+			found = true
+		}
+		if !found {
+			t.Errorf("HSTS header missing required component: %s", component)
+		}
+	}
+}
+
+func TestSecurityHeadersMiddleware_CSP_Directives(t *testing.T) {
+	// Set Gin to test mode
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(securityHeadersMiddleware())
+	router.GET("/test", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	req, _ := http.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	cspHeader := w.Header().Get("Content-Security-Policy")
+
+	if cspHeader == "" {
+		t.Fatal("CSP header is not set")
+	}
+
+	// Verify important CSP directives are present
+	requiredDirectives := []string{
+		"default-src 'self'",
+		"script-src 'self'",
+		"object-src 'none'",
+		"frame-ancestors 'none'",
+	}
+
+	for _, directive := range requiredDirectives {
+		if !containsString(cspHeader, directive) {
+			t.Errorf("CSP header missing required directive: %s", directive)
+		}
+	}
+}
+
+// Helper function to check if a string contains a substring
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsInMiddle(s, substr)))
+}
+
+func containsInMiddle(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -85,6 +85,7 @@ func New(
 
 	r.Use(sloggin.NewWithConfig(log, lmConfig))
 	r.Use(gin.Recovery())
+	r.Use(securityHeadersMiddleware())
 	store := persist.NewMemoryStore(cacheDuration)
 	whService := webhook.NewBatchServiceAdapter(log, dbPool)
 
@@ -178,6 +179,45 @@ func ignoreUserAgentMiddleware(ignoredUserAgents []string) gin.HandlerFunc {
 func cacheControlMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Writer.Header().Set("Cache-Control", "public, max-age=604800, immutable")
+	}
+}
+
+// securityHeadersMiddleware adds recommended security headers to all responses
+func securityHeadersMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// HTTP Strict Transport Security (HSTS)
+		// Instructs browsers to only access the site via HTTPS for the next year
+		// includeSubDomains applies this policy to all subdomains
+		c.Writer.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+
+		// X-Frame-Options
+		// Prevents clickjacking attacks by disallowing the page to be displayed in frames
+		c.Writer.Header().Set("X-Frame-Options", "DENY")
+
+		// X-Content-Type-Options
+		// Prevents MIME-sniffing and forces browser to respect declared content-type
+		c.Writer.Header().Set("X-Content-Type-Options", "nosniff")
+
+		// Content-Security-Policy (CSP)
+		// Defines which resources can be loaded and executed
+		// default-src 'self': Only allow resources from same origin
+		// style-src 'self' 'unsafe-inline': Allow inline styles (needed for many frameworks)
+		// script-src 'self': Only allow scripts from same origin
+		// img-src 'self' data: https:: Allow images from same origin, data URIs, and HTTPS sources
+		// font-src 'self': Only allow fonts from same origin
+		c.Writer.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: https:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';")
+
+		// Referrer-Policy
+		// Controls how much referrer information is sent with requests
+		// strict-origin-when-cross-origin: Send full URL for same-origin, only origin for cross-origin
+		c.Writer.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+
+		// Permissions-Policy
+		// Controls which browser features and APIs can be used
+		// Denies access to potentially sensitive features like camera, microphone, geolocation
+		c.Writer.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), interest-cohort=()")
+
+		c.Next()
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR implements comprehensive HTTP security headers middleware to protect against common browser-based attacks including SSL stripping, clickjacking, XSS, MIME-sniffing, and unauthorized feature access.

## Problem Statement

The application was identified as vulnerable to multiple security risks due to missing HTTP response headers:

**Vulnerability:** Server Security Misconfiguration - Lack of Security Headers
**OWASP Severity:** Low
**CVSS v3.1 Score:** Low (3.7)

### Missing Headers

- **Strict-Transport-Security (HSTS)**: Allowed downgrade attacks forcing users onto HTTP and potential SSL stripping
- **Content-Security-Policy (CSP)**: Left application open to XSS and data injection attacks
- **X-Frame-Options**: Enabled clickjacking attacks via iframe embedding
- **X-Content-Type-Options**: Allowed MIME-sniffing leading to content-type confusion
- **Referrer-Policy**: Exposed sensitive URL parameters to third parties via Referer header
- **Permissions-Policy**: Failed to restrict browser features (camera, microphone, geolocation)

### Affected Resources

- `https://wave.stage-seqera.io/v1alpha1/*` - Missing HSTS header
- `https://community.wave.stage-seqera.io/` - Missing all security headers

## Solution

Implemented a global Gin middleware (`securityHeadersMiddleware`) that adds six critical security headers to all HTTP responses.

### Security Headers Implemented

#### 1. Strict-Transport-Security (HSTS)
```
Strict-Transport-Security: max-age=31536000; includeSubDomains
```
- Forces HTTPS connections for 1 year (31,536,000 seconds)
- Applies to all subdomains
- Prevents SSL stripping attacks

#### 2. X-Frame-Options
```
X-Frame-Options: DENY
```
- Prevents page from being displayed in any frame/iframe
- Blocks clickjacking attacks completely

#### 3. X-Content-Type-Options
```
X-Content-Type-Options: nosniff
```
- Prevents MIME-type sniffing
- Forces browsers to respect declared content-type

#### 4. Content-Security-Policy (CSP)
```
Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline';
  script-src 'self'; img-src 'self' data: https:; font-src 'self';
  object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';
```
**Directives:**
- `default-src 'self'`: Only allow resources from same origin
- `style-src 'self' 'unsafe-inline'`: Allow inline styles (needed for Tailwind CSS)
- `script-src 'self'`: Only allow scripts from same origin
- `img-src 'self' data: https:`: Allow images from same origin, data URIs, and HTTPS
- `font-src 'self'`: Only allow fonts from same origin
- `object-src 'none'`: Block plugins (Flash, etc.)
- `base-uri 'self'`: Prevent base tag injection
- `form-action 'self'`: Only allow form submissions to same origin
- `frame-ancestors 'none'`: Enhanced clickjacking protection

#### 5. Referrer-Policy
```
Referrer-Policy: strict-origin-when-cross-origin
```
- Sends full URL for same-origin requests
- Sends only origin for cross-origin HTTPS requests
- Sends nothing when downgrading from HTTPS to HTTP

#### 6. Permissions-Policy
```
Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
```
- Denies access to camera
- Denies access to microphone
- Denies access to geolocation
- Disables FLoC/interest-cohort tracking

## Changes

### Modified Files

**`pkg/server/server.go`**
- Added `securityHeadersMiddleware()` function (lines 185-221)
- Registered middleware globally in `New()` function (line 88)
- Middleware applied to all routes before request routing

### New Files

**`pkg/server/security_headers_test.go`** (260 lines)
- Comprehensive test suite with 5 test cases
- Tests all 6 security headers
- Validates middleware behavior across multiple endpoints
- Verifies compatibility with other middleware

## Implementation Details

### Middleware Placement

```go
r.Use(sloggin.NewWithConfig(log, lmConfig))
r.Use(gin.Recovery())
r.Use(securityHeadersMiddleware())  // ← Added here (early in chain)
```

**Rationale:**
- Placed after logging and recovery middleware
- Applied before routing to ensure all responses include headers
- Runs for all endpoints (API, HTML, static assets)

### Test Coverage

#### TestSecurityHeadersMiddleware
Validates all six headers are set with correct values:
```go
✓ Strict-Transport-Security: max-age=31536000; includeSubDomains
✓ X-Frame-Options: DENY
✓ X-Content-Type-Options: nosniff
✓ Content-Security-Policy: [full policy]
✓ Referrer-Policy: strict-origin-when-cross-origin
✓ Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
```

#### TestSecurityHeadersMiddleware_MultipleRequests
- Tests GET and POST endpoints
- Verifies headers across different status codes (200, 201)
- Ensures consistency across all routes

#### TestSecurityHeadersMiddleware_WithOtherMiddleware
- Validates no conflicts with existing middleware
- Confirms custom headers are preserved

#### TestSecurityHeadersMiddleware_HSTS_Format
- Verifies HSTS max-age directive
- Confirms includeSubDomains flag present

#### TestSecurityHeadersMiddleware_CSP_Directives
- Validates critical CSP directives
- Ensures protection against XSS and injection attacks

### Test Results

```bash
$ go test ./pkg/server/... -v
=== RUN   TestSecurityHeadersMiddleware
=== RUN   TestSecurityHeadersMiddleware/Strict-Transport-Security_header
=== RUN   TestSecurityHeadersMiddleware/X-Frame-Options_header
=== RUN   TestSecurityHeadersMiddleware/X-Content-Type-Options_header
=== RUN   TestSecurityHeadersMiddleware/Content-Security-Policy_header
=== RUN   TestSecurityHeadersMiddleware/Referrer-Policy_header
=== RUN   TestSecurityHeadersMiddleware/Permissions-Policy_header
--- PASS: TestSecurityHeadersMiddleware (0.00s)
[...]
PASS
ok      github.com/seqeralabs/staticreg/pkg/server    2.100s
```

**All tests passing** - No regressions introduced

## Security Impact

### Before
```http
HTTP/2 200 OK
Content-Type: application/json
[No security headers]
```

### After
```http
HTTP/2 200 OK
Content-Type: application/json
Strict-Transport-Security: max-age=31536000; includeSubDomains
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'; [...]
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
```

## Verification

### Manual Testing

```bash
# Build and run the application
make _output/dist
./staticreg serve

# Test headers with curl
curl -I http://localhost:8080/

# Expected output includes:
# Strict-Transport-Security: max-age=31536000; includeSubDomains
# X-Frame-Options: DENY
# X-Content-Type-Options: nosniff
# Content-Security-Policy: [...]
# Referrer-Policy: strict-origin-when-cross-origin
# Permissions-Policy: [...]
```

### Browser Testing

Use browser DevTools to verify:
1. Network tab → Response Headers
2. Security scan tools (Mozilla Observatory, SecurityHeaders.com)
3. OWASP ZAP automated scan

## Configuration Notes

### CSP Customization

The current CSP policy allows `'unsafe-inline'` for styles to support Tailwind CSS. If your application requires stricter CSP:

```go
// Remove 'unsafe-inline' and use nonces
c.Writer.Header().Set("Content-Security-Policy",
  "style-src 'self' 'nonce-{random}'")
```

### HSTS Considerations

- **max-age=31536000**: 1 year HSTS duration (recommended minimum: 6 months)
- **includeSubDomains**: Applies to all subdomains (ensure all subdomains support HTTPS)
- **preload**: Not included (requires HTTPS on all subdomains + manual submission to browsers)

To enable HSTS preload:
```go
c.Writer.Header().Set("Strict-Transport-Security",
  "max-age=63072000; includeSubDomains; preload")
```

## References

- [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/)
- [MDN - HTTP Strict Transport Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
- [Content Security Policy Reference](https://content-security-policy.com/)
- [Permissions Policy](https://www.w3.org/TR/permissions-policy-1/)
- [Mozilla Observatory](https://observatory.mozilla.org/)

## Checklist

- [x] Security headers middleware implemented
- [x] All 6 critical headers configured
- [x] Comprehensive unit tests added (5 test cases)
- [x] All existing tests passing (no regressions)
- [x] Code compiles successfully
- [x] Middleware registered globally
- [x] Headers applied to all routes
- [x] Documentation included in code comments
- [x] OWASP recommendations followed

## Review Focus Areas

1. **CSP Policy** (`pkg/server/server.go:207`)
   - Verify `'unsafe-inline'` is acceptable for your use case
   - Consider if additional directives needed for external resources

2. **HSTS Configuration** (`pkg/server/server.go:190`)
   - Confirm 1-year max-age is appropriate
   - Verify all subdomains support HTTPS before deploying

3. **Middleware Order** (`pkg/server/server.go:88`)
   - Placed after recovery but before routing
   - Ensures headers on all responses (including errors)

4. **Test Coverage** (`pkg/server/security_headers_test.go`)
   - All headers tested with exact value matching
   - Edge cases covered (multiple requests, middleware interaction)

---

**Resolves:** Server Security Misconfiguration vulnerability (OWASP Low, CVSS 3.7)
**Impact:** Hardens application against clickjacking, XSS, SSL stripping, and MIME-sniffing attacks