### PR TITLE
feat(db): TLS-by-default + tunable connection pool (PR2/3)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -50,8 +50,18 @@ Configuration for PostgreSQL connection and pooling.
 | `STATICREG_DB_USER` | string | *(required)* | PostgreSQL username. Alternative to `STATICREG_DB_URL`. Required if using individual variables. |
 | `STATICREG_DB_PASSWORD` | string | *(optional)* | PostgreSQL password. Alternative to `STATICREG_DB_URL`. |
 | `STATICREG_DB_NAME` | string | *(required)* | PostgreSQL database name. Alternative to `STATICREG_DB_URL`. Required if using individual variables. |
-| `STATICREG_DB_SSLMODE` | string | *(optional)* | PostgreSQL SSL mode. Options: `disable`, `require`, `verify-ca`, `verify-full`. Alternative to `STATICREG_DB_URL`. |
+| `STATICREG_DB_SSLMODE` | string | `require` | PostgreSQL SSL mode. Options: `disable`, `require`, `verify-ca`, `verify-full`. Applies only when individual `STATICREG_DB_*` variables are used; with `STATICREG_DB_URL`, encode `?sslmode=...` in the URL instead. **TLS is enforced by default** — set this to `disable` to opt out (a warning is logged at startup so insecure deployments are visible). |
 | `STATICREG_DB_SCHEMA` | string | `staticreg` | PostgreSQL schema where StaticReg owns its tables. The schema is created on startup if missing and is set as the connection `search_path`. Must match `^[a-z_][a-z0-9_]*$` (lowercase letters, digits, underscores; max 63 chars). Use a per-deployment value (e.g. `staticreg_prod`) when multiple StaticReg instances share a database. |
+| `STATICREG_DB_MAX_CONNS` | integer | `25` | Maximum number of open connections in the pool. Increase for high-concurrency workloads; coordinate with the postgres `max_connections` setting. |
+| `STATICREG_DB_MIN_CONNS` | integer | `2` | Minimum number of idle connections kept warm in the pool. |
+| `STATICREG_DB_MAX_CONN_LIFETIME` | duration | `1h` | Maximum lifetime of a connection before it is rotated. Encourages load balancing across postgres replicas and recovery from stale state. |
+| `STATICREG_DB_MAX_CONN_IDLE_TIME` | duration | `30m` | Maximum time an idle connection is kept before being closed. |
+| `STATICREG_DB_HEALTHCHECK_PERIOD` | duration | `1m` | How often the pool runs background health checks on idle connections. |
+
+#### Migration notes (v0.7 → v0.8)
+
+- **TLS default changed.** Previously, an unset `STATICREG_DB_SSLMODE` produced `sslmode=disable` (no TLS). It now defaults to `sslmode=require`. Deployments that rely on plaintext connections must set `STATICREG_DB_SSLMODE=disable` explicitly; a warning will be logged on startup.
+- **Pool tuning is now configurable.** The previously-hardcoded `MaxConns=25` is now the default for `STATICREG_DB_MAX_CONNS`; behavior is unchanged unless you override it.
 
 
 ### Registry Configuration

--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -93,6 +93,38 @@ spec:
                   key: STATICREG_DB_SCHEMA
                   optional: true
 
+            # Database Connection Pool Tuning (all optional)
+            - name: STATICREG_DB_MAX_CONNS
+              valueFrom:
+                configMapKeyRef:
+                  name: staticreg-config
+                  key: STATICREG_DB_MAX_CONNS
+                  optional: true
+            - name: STATICREG_DB_MIN_CONNS
+              valueFrom:
+                configMapKeyRef:
+                  name: staticreg-config
+                  key: STATICREG_DB_MIN_CONNS
+                  optional: true
+            - name: STATICREG_DB_MAX_CONN_LIFETIME
+              valueFrom:
+                configMapKeyRef:
+                  name: staticreg-config
+                  key: STATICREG_DB_MAX_CONN_LIFETIME
+                  optional: true
+            - name: STATICREG_DB_MAX_CONN_IDLE_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: staticreg-config
+                  key: STATICREG_DB_MAX_CONN_IDLE_TIME
+                  optional: true
+            - name: STATICREG_DB_HEALTHCHECK_PERIOD
+              valueFrom:
+                configMapKeyRef:
+                  name: staticreg-config
+                  key: STATICREG_DB_HEALTHCHECK_PERIOD
+                  optional: true
+
             # Webhook Batching Configuration
             - name: STATICREG_METRICS_BATCH_SIZE
               valueFrom:

--- a/pkg/cfg/env.go
+++ b/pkg/cfg/env.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Seqera
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cfg
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// EnvInt reads an integer from the named environment variable. Falls back to
+// def if the variable is unset or unparseable.
+func EnvInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+// EnvDuration reads a Go duration (see time.ParseDuration) from the named
+// environment variable. Falls back to def if the variable is unset or
+// unparseable.
+func EnvDuration(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}

--- a/pkg/cfg/env_test.go
+++ b/pkg/cfg/env_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Seqera
+
+package cfg
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEnvInt(t *testing.T) {
+	t.Run("unset returns default", func(t *testing.T) {
+		if got := EnvInt("STATICREG_TEST_NONEXISTENT", 42); got != 42 {
+			t.Errorf("got %d, want 42", got)
+		}
+	})
+
+	t.Run("parses valid int", func(t *testing.T) {
+		t.Setenv("STATICREG_TEST_INT", "7")
+		if got := EnvInt("STATICREG_TEST_INT", 42); got != 7 {
+			t.Errorf("got %d, want 7", got)
+		}
+	})
+
+	t.Run("invalid value falls back to default", func(t *testing.T) {
+		t.Setenv("STATICREG_TEST_INT", "not-a-number")
+		if got := EnvInt("STATICREG_TEST_INT", 42); got != 42 {
+			t.Errorf("got %d, want 42", got)
+		}
+	})
+}
+
+func TestEnvDuration(t *testing.T) {
+	t.Run("unset returns default", func(t *testing.T) {
+		if got := EnvDuration("STATICREG_TEST_NONEXISTENT", 5*time.Second); got != 5*time.Second {
+			t.Errorf("got %v, want 5s", got)
+		}
+	})
+
+	t.Run("parses valid duration", func(t *testing.T) {
+		t.Setenv("STATICREG_TEST_DUR", "30s")
+		if got := EnvDuration("STATICREG_TEST_DUR", 5*time.Second); got != 30*time.Second {
+			t.Errorf("got %v, want 30s", got)
+		}
+	})
+
+	t.Run("invalid value falls back to default", func(t *testing.T) {
+		t.Setenv("STATICREG_TEST_DUR", "five seconds")
+		if got := EnvDuration("STATICREG_TEST_DUR", 5*time.Second); got != 5*time.Second {
+			t.Errorf("got %v, want 5s", got)
+		}
+	})
+}

--- a/pkg/db/postgres.go
+++ b/pkg/db/postgres.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
+	"github.com/seqeralabs/staticreg/pkg/cfg"
 	"github.com/seqeralabs/staticreg/pkg/observability/logger"
 	schemasql "github.com/seqeralabs/staticreg/pkg/sql"
 )
@@ -41,12 +42,12 @@ func resolveSchema() (string, error) {
 // It prioritizes STATICREG_DB_URL if set, otherwise builds the connection string from individual
 // STATICREG_DB_* environment variables. Returns empty string if no configuration is provided.
 func buildConnectionString() string {
-	// First, check if STATICREG_DB_URL is provided (highest priority)
+	// STATICREG_DB_URL is taken as-is — the user already has full control over
+	// sslmode via the query string.
 	if connStr := os.Getenv("STATICREG_DB_URL"); connStr != "" {
 		return connStr
 	}
 
-	// Build connection string from individual components
 	host := os.Getenv("STATICREG_DB_HOST")
 	port := os.Getenv("STATICREG_DB_PORT")
 	user := os.Getenv("STATICREG_DB_USER")
@@ -54,23 +55,23 @@ func buildConnectionString() string {
 	dbname := os.Getenv("STATICREG_DB_NAME")
 	sslmode := os.Getenv("STATICREG_DB_SSLMODE")
 
-	// Require at minimum: host, user, and dbname
 	if host == "" || user == "" || dbname == "" {
 		return ""
 	}
 
-	// Build the connection string with required fields
-	connStr := fmt.Sprintf("host=%s user=%s dbname=%s", host, user, dbname)
+	// Default to TLS-enforced so production deployments encrypt traffic
+	// without explicit opt-in. Operators must set sslmode=disable explicitly
+	// to opt out (see the warn in InitPool).
+	if sslmode == "" {
+		sslmode = "require"
+	}
 
-	// Add optional fields if provided
+	connStr := fmt.Sprintf("host=%s user=%s dbname=%s sslmode=%s", host, user, dbname, sslmode)
 	if port != "" {
 		connStr += fmt.Sprintf(" port=%s", port)
 	}
 	if password != "" {
 		connStr += fmt.Sprintf(" password=%s", password)
-	}
-	if sslmode != "" {
-		connStr += fmt.Sprintf(" sslmode=%s", sslmode)
 	}
 
 	return connStr
@@ -99,6 +100,13 @@ func InitPool() *pgxpool.Pool {
 		return nil
 	}
 
+	// pgx leaves TLSConfig nil only when sslmode=disable. Warn loudly so
+	// insecure deployments are visible in logs even if the operator chose to
+	// opt out explicitly.
+	if config.ConnConfig.TLSConfig == nil {
+		slog.Warn("postgres TLS is disabled (sslmode=disable). Database traffic is unencrypted. Set STATICREG_DB_SSLMODE=require (or higher) for production.")
+	}
+
 	// Pin every pooled connection to the dedicated schema so unqualified
 	// identifiers in queries (and goose's bookkeeping table) resolve there.
 	if config.ConnConfig.RuntimeParams == nil {
@@ -106,8 +114,7 @@ func InitPool() *pgxpool.Pool {
 	}
 	config.ConnConfig.RuntimeParams["search_path"] = schema
 
-	// Configure connection pool settings
-	config.MaxConns = 25
+	applyPoolTuning(config)
 
 	// Short timeout for pool construction + initial ping. A separate, longer
 	// budget is used for migrations below — running goose under the same
@@ -172,4 +179,23 @@ func initSchema(ctx context.Context, pool *pgxpool.Pool, schema string) error {
 
 	slog.Info("Database schema ready.", slog.String("schema", schema))
 	return nil
+}
+
+// applyPoolTuning sets pool sizing and lifetimes from STATICREG_DB_* env vars.
+// Defaults preserve historical behavior (MaxConns=25) while letting operators
+// tune for their workload without rebuilding.
+func applyPoolTuning(config *pgxpool.Config) {
+	config.MaxConns = int32(cfg.EnvInt("STATICREG_DB_MAX_CONNS", 25))
+	config.MinConns = int32(cfg.EnvInt("STATICREG_DB_MIN_CONNS", 2))
+	config.MaxConnLifetime = cfg.EnvDuration("STATICREG_DB_MAX_CONN_LIFETIME", time.Hour)
+	config.MaxConnIdleTime = cfg.EnvDuration("STATICREG_DB_MAX_CONN_IDLE_TIME", 30*time.Minute)
+	config.HealthCheckPeriod = cfg.EnvDuration("STATICREG_DB_HEALTHCHECK_PERIOD", time.Minute)
+
+	slog.Info("PostgreSQL pool tuning",
+		slog.Int("max_conns", int(config.MaxConns)),
+		slog.Int("min_conns", int(config.MinConns)),
+		slog.Duration("max_conn_lifetime", config.MaxConnLifetime),
+		slog.Duration("max_conn_idle_time", config.MaxConnIdleTime),
+		slog.Duration("healthcheck_period", config.HealthCheckPeriod),
+	)
 }

--- a/pkg/db/postgres_test.go
+++ b/pkg/db/postgres_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Seqera
+
+package db
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func clearDBEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"STATICREG_DB_URL",
+		"STATICREG_DB_HOST",
+		"STATICREG_DB_PORT",
+		"STATICREG_DB_USER",
+		"STATICREG_DB_PASSWORD",
+		"STATICREG_DB_NAME",
+		"STATICREG_DB_SSLMODE",
+		"STATICREG_DB_SCHEMA",
+		"STATICREG_DB_MAX_CONNS",
+		"STATICREG_DB_MIN_CONNS",
+		"STATICREG_DB_MAX_CONN_LIFETIME",
+		"STATICREG_DB_MAX_CONN_IDLE_TIME",
+		"STATICREG_DB_HEALTHCHECK_PERIOD",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestBuildConnectionString(t *testing.T) {
+	t.Run("URL is returned verbatim", func(t *testing.T) {
+		clearDBEnv(t)
+		url := "postgres://u:p@h:5432/db?sslmode=require"
+		t.Setenv("STATICREG_DB_URL", url)
+		if got := buildConnectionString(); got != url {
+			t.Fatalf("got %q, want %q", got, url)
+		}
+	})
+
+	t.Run("missing required fields returns empty", func(t *testing.T) {
+		clearDBEnv(t)
+		t.Setenv("STATICREG_DB_HOST", "h")
+		// USER and NAME unset
+		if got := buildConnectionString(); got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("sslmode defaults to require when unset", func(t *testing.T) {
+		clearDBEnv(t)
+		t.Setenv("STATICREG_DB_HOST", "h")
+		t.Setenv("STATICREG_DB_USER", "u")
+		t.Setenv("STATICREG_DB_NAME", "db")
+		got := buildConnectionString()
+		if !strings.Contains(got, "sslmode=require") {
+			t.Fatalf("expected sslmode=require in %q", got)
+		}
+	})
+
+	t.Run("explicit sslmode is respected", func(t *testing.T) {
+		clearDBEnv(t)
+		t.Setenv("STATICREG_DB_HOST", "h")
+		t.Setenv("STATICREG_DB_USER", "u")
+		t.Setenv("STATICREG_DB_NAME", "db")
+		t.Setenv("STATICREG_DB_SSLMODE", "verify-full")
+		got := buildConnectionString()
+		if !strings.Contains(got, "sslmode=verify-full") {
+			t.Fatalf("expected sslmode=verify-full in %q", got)
+		}
+		if strings.Contains(got, "sslmode=require") {
+			t.Fatalf("did not expect sslmode=require in %q", got)
+		}
+	})
+
+	t.Run("explicit sslmode=disable is respected", func(t *testing.T) {
+		clearDBEnv(t)
+		t.Setenv("STATICREG_DB_HOST", "h")
+		t.Setenv("STATICREG_DB_USER", "u")
+		t.Setenv("STATICREG_DB_NAME", "db")
+		t.Setenv("STATICREG_DB_SSLMODE", "disable")
+		got := buildConnectionString()
+		if !strings.Contains(got, "sslmode=disable") {
+			t.Fatalf("expected sslmode=disable in %q", got)
+		}
+	})
+
+	t.Run("optional fields are appended when set", func(t *testing.T) {
+		clearDBEnv(t)
+		t.Setenv("STATICREG_DB_HOST", "h")
+		t.Setenv("STATICREG_DB_USER", "u")
+		t.Setenv("STATICREG_DB_NAME", "db")
+		t.Setenv("STATICREG_DB_PORT", "5433")
+		t.Setenv("STATICREG_DB_PASSWORD", "secret")
+		got := buildConnectionString()
+		for _, want := range []string{"port=5433", "password=secret"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("expected %q in %q", want, got)
+			}
+		}
+	})
+}
+
+func TestApplyPoolTuning(t *testing.T) {
+	t.Run("defaults applied when env unset", func(t *testing.T) {
+		clearDBEnv(t)
+		c, err := pgxpool.ParseConfig("postgres://u:p@h/db")
+		if err != nil {
+			t.Fatal(err)
+		}
+		applyPoolTuning(c)
+		if c.MaxConns != 25 {
+			t.Errorf("MaxConns: got %d, want 25", c.MaxConns)
+		}
+		if c.MinConns != 2 {
+			t.Errorf("MinConns: got %d, want 2", c.MinConns)
+		}
+		if c.MaxConnLifetime != time.Hour {
+			t.Errorf("MaxConnLifetime: got %v, want 1h", c.MaxConnLifetime)
+		}
+		if c.MaxConnIdleTime != 30*time.Minute {
+			t.Errorf("MaxConnIdleTime: got %v, want 30m", c.MaxConnIdleTime)
+		}
+		if c.HealthCheckPeriod != time.Minute {
+			t.Errorf("HealthCheckPeriod: got %v, want 1m", c.HealthCheckPeriod)
+		}
+	})
+
+	t.Run("env overrides apply", func(t *testing.T) {
+		clearDBEnv(t)
+		t.Setenv("STATICREG_DB_MAX_CONNS", "100")
+		t.Setenv("STATICREG_DB_MIN_CONNS", "10")
+		t.Setenv("STATICREG_DB_MAX_CONN_LIFETIME", "2h")
+		t.Setenv("STATICREG_DB_MAX_CONN_IDLE_TIME", "15m")
+		t.Setenv("STATICREG_DB_HEALTHCHECK_PERIOD", "30s")
+
+		c, err := pgxpool.ParseConfig("postgres://u:p@h/db")
+		if err != nil {
+			t.Fatal(err)
+		}
+		applyPoolTuning(c)
+		if c.MaxConns != 100 {
+			t.Errorf("MaxConns: got %d, want 100", c.MaxConns)
+		}
+		if c.MinConns != 10 {
+			t.Errorf("MinConns: got %d, want 10", c.MinConns)
+		}
+		if c.MaxConnLifetime != 2*time.Hour {
+			t.Errorf("MaxConnLifetime: got %v, want 2h", c.MaxConnLifetime)
+		}
+		if c.MaxConnIdleTime != 15*time.Minute {
+			t.Errorf("MaxConnIdleTime: got %v, want 15m", c.MaxConnIdleTime)
+		}
+		if c.HealthCheckPeriod != 30*time.Second {
+			t.Errorf("HealthCheckPeriod: got %v, want 30s", c.HealthCheckPeriod)
+		}
+	})
+}

--- a/pkg/webhook/batchserviceadapter.go
+++ b/pkg/webhook/batchserviceadapter.go
@@ -18,14 +18,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/seqeralabs/staticreg/pkg/cfg"
 )
 
 // BatchServiceAdapter processes webhook events asynchronously with batching
@@ -54,9 +53,9 @@ type BatchServiceAdapter struct {
 //   - STATICREG_METRICS_FLUSH_INTERVAL: Time interval to force flush (default: 5s)
 //   - STATICREG_METRICS_BUFFER_SIZE: Channel buffer size (default: 10000)
 func NewBatchServiceAdapter(log *slog.Logger, pool *pgxpool.Pool) *BatchServiceAdapter {
-	batchSize := getEnvInt("STATICREG_METRICS_BATCH_SIZE", 100)
-	flushInterval := getEnvDuration("STATICREG_METRICS_FLUSH_INTERVAL", 5*time.Second)
-	bufferSize := getEnvInt("STATICREG_METRICS_BUFFER_SIZE", 10000)
+	batchSize := cfg.EnvInt("STATICREG_METRICS_BATCH_SIZE", 100)
+	flushInterval := cfg.EnvDuration("STATICREG_METRICS_FLUSH_INTERVAL", 5*time.Second)
+	bufferSize := cfg.EnvInt("STATICREG_METRICS_BUFFER_SIZE", 10000)
 
 	adapter := &BatchServiceAdapter{
 		Logger:        log,
@@ -270,22 +269,3 @@ func (a *BatchServiceAdapter) GetMetrics() map[string]int64 {
 	}
 }
 
-// getEnvInt reads an integer from environment variable with a default fallback
-func getEnvInt(key string, defaultValue int) int {
-	if val := os.Getenv(key); val != "" {
-		if intVal, err := strconv.Atoi(val); err == nil {
-			return intVal
-		}
-	}
-	return defaultValue
-}
-
-// getEnvDuration reads a duration from environment variable with a default fallback
-func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
-	if val := os.Getenv(key); val != "" {
-		if duration, err := time.ParseDuration(val); err == nil {
-			return duration
-		}
-	}
-	return defaultValue
-}

--- a/pkg/webhook/batchserviceadapter_test.go
+++ b/pkg/webhook/batchserviceadapter_test.go
@@ -179,18 +179,3 @@ func TestBatchServiceAdapter_MetricsTracking(t *testing.T) {
 	_ = adapter.Close(5 * time.Second)
 }
 
-func TestGetEnvInt(t *testing.T) {
-	// Test default value
-	val := getEnvInt("NONEXISTENT_ENV_VAR", 42)
-	if val != 42 {
-		t.Errorf("Expected default value 42, got %d", val)
-	}
-}
-
-func TestGetEnvDuration(t *testing.T) {
-	// Test default value
-	val := getEnvDuration("NONEXISTENT_ENV_VAR", 5*time.Second)
-	if val != 5*time.Second {
-		t.Errorf("Expected default value 5s, got %v", val)
-	}
-}


### PR DESCRIPTION
## Summary

**PR 2 of 3** in the postgres enterprise hardening plan. Stacked on #64 — please review/merge that first.

- Default `STATICREG_DB_SSLMODE` to `require` (was implicitly `disable`). `STATICREG_DB_URL` is left untouched; sslmode is encoded in the URL.
- Warn loudly at startup whenever the resolved sslmode is `disable`, detected via pgx's `TLSConfig == nil`. Operators who opt out explicitly still see a single conspicuous log line so insecure deployments are visible in production logs.
- Add five tunable pool knobs, all defaulting to current behavior so existing deployments are unaffected: `STATICREG_DB_MAX_CONNS` (25), `MIN_CONNS` (2), `MAX_CONN_LIFETIME` (1h), `MAX_CONN_IDLE_TIME` (30m), `HEALTHCHECK_PERIOD` (1m). Resolved settings are logged at startup.
- Promote `getEnvInt` / `getEnvDuration` from `pkg/webhook` to shared `pkg/cfg.EnvInt` / `cfg.EnvDuration`. Both `pkg/db` and `pkg/webhook` now use the single implementation.
- Surface the new pool-tuning vars in `manifests/deployment.yml` as optional ConfigMap-sourced env. Document them and the TLS default change in `docs/CONFIGURATION.md` with a "Migration notes (v0.7 → v0.8)" subsection.

## Behavior change for operators

**Breaking, by design:** any deployment that was relying on an unset `STATICREG_DB_SSLMODE` (effectively `disable`) will now attempt TLS. Postgres servers without TLS configured will fail to connect. Operators must either:

- enable TLS on the database (recommended), **or**
- explicitly set `STATICREG_DB_SSLMODE=disable` and accept the warning log line.

The migration notes in `docs/CONFIGURATION.md` document this.

## What's not in this PR (queued for PR 3/3)

- DB health endpoint (`/healthz/db`) and pool metrics export.
- Kubernetes readiness/liveness probes wired to it.
- Production checklist + ops runbook docs.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` (unit) passes — includes new tests for `buildConnectionString` (URL passthrough, missing fields, sslmode default + override, optional fields) and `applyPoolTuning` (defaults + env overrides), plus tests for the promoted `cfg.EnvInt`/`cfg.EnvDuration`
- [x] `go test -tags=integration ./pkg/db/... ./pkg/webhook/...` passes against `docker compose up postgres`
- [x] TLS warning fires when running with `STATICREG_DB_SSLMODE=disable`
- [x] Pool tuning info-log fires at startup with the resolved values
- [ ] Reviewer to verify a staging deployment with `STATICREG_DB_MAX_CONNS=100` shows the override in the startup log

🤖 Generated with [Claude Code](https://claude.com/claude-code)