### PR TITLE
feat(server): DB health + pool/webhook metrics endpoints (PR3/3)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,11 +60,32 @@ PostgreSQL integration for storing container pull/push metrics:
 - Graceful degradation when database is unavailable
 - Schema validation on startup
 
+**Schema Isolation:**
+- All StaticReg tables live in a dedicated postgres schema (default: `staticreg`),
+  never `public`. The schema name is configurable via `STATICREG_DB_SCHEMA` and
+  is set as `search_path` on every pooled connection, so unqualified queries
+  resolve there transparently.
+- This isolation is what makes a single postgres instance safely usable for
+  multiple StaticReg deployments (e.g. `staticreg_prod`, `staticreg_staging`)
+  and for shared databases owned by other applications.
+
 **Schema Management (`pkg/sql`):**
-- SQL schema embedded using Go's `embed` feature
-- Source: `pkg/sql/event_schema.sql`
-- Automatic initialization filters out destructive operations (DROP TABLE)
-- Manual setup supported via `sql/event_schema.sql`
+- Migrations are versioned `.sql` files under `pkg/sql/migrations/`, embedded
+  via `embed.FS` and applied with [pressly/goose](https://github.com/pressly/goose)
+  on startup.
+- The `goose_db_version` table lives inside the dedicated schema and tracks
+  applied versions; reruns are no-ops once all migrations are up.
+- See [`docs/POSTGRES_OPERATIONS.md`](POSTGRES_OPERATIONS.md) for adding new
+  migrations and rolling back.
+
+**Health & Observability:**
+- `GET /healthz` — process liveness, no DB dependency.
+- `GET /healthz/db` — readiness; pings the pool with a 750ms timeout, returns
+  503 if the pool is unconfigured or the ping fails.
+- `GET /metrics/db` — JSON snapshot of `pgxpool.Stat()` (acquired/idle/max
+  conns, acquire counts, lifetime destroy counts).
+- `GET /metrics/webhook` — JSON snapshot of the batched webhook adapter's
+  counters (events received/dropped/flushed, batch count, queue size).
 
 **Database Schema:**
 - `container_pull_metrics` - Aggregated pull metrics table

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -270,5 +270,45 @@ export STATICREG_METRICS_BUFFER_SIZE=1000
 
 ```
 
+## Health and Metrics Endpoints
+
+The HTTP server exposes four operational endpoints on the same port as the
+application (default `:8093`). All return JSON.
+
+| Endpoint | Purpose | Status codes |
+|---|---|---|
+| `GET /healthz` | Process liveness. Returns `{"status":"ok"}` whenever the server can respond to HTTP. **No DB dependency** — a transient DB outage does not cause this to fail, so it is safe for a Kubernetes liveness probe (avoids restart storms). | 200 only |
+| `GET /healthz/db` | Database readiness. Pings the pool with a 750ms timeout. Wire to a Kubernetes readiness probe to drain a pod that has lost its DB connection. | 200 / 503 |
+| `GET /metrics/db` | Snapshot of `pgxpool.Stat()` — acquired/idle/max conns, acquire counts, lifetime destroy counts. | 200 / 503 |
+| `GET /metrics/webhook` | Snapshot of the batched webhook adapter's counters — events received/dropped/flushed, batches flushed, current queue size. | 200 / 503 |
+
+These endpoints are exempt from the `--ignored-user-agent` filter, so probe
+clients (e.g. `kube-probe`) cannot be silenced by an operator's flag.
+
+A future Prometheus integration can wrap these JSON shapes without changing
+the underlying data sources.
+
+## Production Checklist
+
+Before deploying StaticReg with postgres in a shared or production environment:
+
+- [ ] **TLS enabled.** `STATICREG_DB_SSLMODE` set to `require`, `verify-ca`, or
+      `verify-full` (or omitted, since `require` is now the default). If you see
+      a `postgres TLS is disabled (sslmode=disable)` warning at startup, fix it.
+- [ ] **Dedicated schema.** `STATICREG_DB_SCHEMA` set to a per-deployment
+      identifier (e.g. `staticreg_prod`) when sharing a database with other
+      applications.
+- [ ] **Pool sizing matches workload.** Tune `STATICREG_DB_MAX_CONNS` and
+      `STATICREG_DB_MIN_CONNS`; coordinate `MAX_CONNS` with postgres'
+      `max_connections` so the pool cannot exhaust the server.
+- [ ] **Probes wired.** Kubernetes `livenessProbe` → `/healthz`, `readinessProbe`
+      → `/healthz/db`. See `manifests/deployment.yml` for the canonical config.
+- [ ] **Secrets.** All `STATICREG_DB_*` credentials sourced from Kubernetes
+      Secrets (or your platform's secret store), never embedded in manifests.
+- [ ] **Migrations strategy understood.** See
+      [POSTGRES_OPERATIONS.md](POSTGRES_OPERATIONS.md) for adding new migrations,
+      rolling back, and inspecting the `goose_db_version` table.
+
 ## Related Documentation
 - [Webhook Batching Architecture](WEBHOOK_BATCHING.md)
+- [Postgres Operations](POSTGRES_OPERATIONS.md)

--- a/docs/POSTGRES_OPERATIONS.md
+++ b/docs/POSTGRES_OPERATIONS.md
@@ -1,0 +1,136 @@
+# Postgres Operations
+
+Operational guidance for running StaticReg's postgres integration in production.
+For full configuration reference see [CONFIGURATION.md](CONFIGURATION.md).
+
+## Schema layout
+
+StaticReg owns a single dedicated schema (default `staticreg`, configurable via
+`STATICREG_DB_SCHEMA`). Two tables live there:
+
+- `container_pull_metrics` — aggregated pull events.
+- `goose_db_version` — migration bookkeeping (managed by goose; do not edit by
+  hand).
+
+The schema is created on startup with `CREATE SCHEMA IF NOT EXISTS`, and every
+pooled connection has `search_path` set to it.
+
+## Inspecting state
+
+```sql
+-- Confirm StaticReg's schema exists and is the active search_path
+SHOW search_path;
+\dn
+
+-- List StaticReg's tables
+\dt staticreg.*
+
+-- Check the migration version
+SELECT version_id, is_applied, tstamp
+FROM staticreg.goose_db_version
+ORDER BY id;
+```
+
+The same information is reachable via the HTTP API:
+
+```bash
+curl -k https://<host>:8093/healthz/db    # 200 if pool can ping
+curl -k https://<host>:8093/metrics/db    # pgxpool stats as JSON
+```
+
+## Adding a new migration
+
+1. Create `pkg/sql/migrations/NNNNN_<short_description>.sql` with the next
+   sequential prefix (e.g. `00002_add_image_size_column.sql`).
+2. Use goose's annotation markers:
+
+   ```sql
+   -- +goose Up
+   -- +goose StatementBegin
+   ALTER TABLE container_pull_metrics ADD COLUMN image_size BIGINT;
+   -- +goose StatementEnd
+
+   -- +goose Down
+   -- +goose StatementBegin
+   ALTER TABLE container_pull_metrics DROP COLUMN image_size;
+   -- +goose StatementEnd
+   ```
+
+3. Build & run StaticReg locally against `docker compose up postgres`. The new
+   migration runs automatically on startup; check the logs for
+   `Database schema ready.`
+4. Verify the change is visible in `staticreg.goose_db_version` and idempotent
+   on a second startup.
+
+**Notes:**
+
+- Migrations run in numeric order. Never renumber or rewrite a migration that
+  has been applied to a deployed database — write a new one instead.
+- All DDL must be schema-unqualified inside migration files. The pool's
+  `search_path` puts new objects in the dedicated schema automatically; using
+  `public.foo` or hardcoding `staticreg.foo` defeats the schema-isolation guarantee.
+- Wrap multi-statement migrations in `StatementBegin`/`StatementEnd` so goose
+  treats them atomically. Single statements do not need the markers.
+
+## Rolling back
+
+StaticReg does not ship a goose CLI binary. To roll back a migration in
+production:
+
+1. Bring up an out-of-band container that has goose installed *and* mounts the
+   `pkg/sql/migrations/` directory:
+
+   ```bash
+   docker run --rm -it \
+     -v "$PWD/pkg/sql/migrations:/migrations:ro" \
+     -e GOOSE_DRIVER=postgres \
+     -e GOOSE_DBSTRING="host=$DB_HOST user=$DB_USER password=$DB_PASS dbname=$DB_NAME sslmode=require search_path=staticreg" \
+     ghcr.io/pressly/goose:latest \
+     -dir /migrations down
+   ```
+
+2. Or, equivalently, run a manual `DROP`/`ALTER` matching the `-- +goose Down`
+   block of the migration you want to revert, then `DELETE FROM
+   staticreg.goose_db_version WHERE version_id = <N>;`.
+
+The `down` path is rarely used in practice — prefer rolling forward with a new
+migration that undoes the change.
+
+## Pool tuning guidance
+
+| Workload | Suggested settings |
+|---|---|
+| Default | (leave defaults: `MAX_CONNS=25`, `MIN_CONNS=2`, `MAX_CONN_LIFETIME=1h`, `MAX_CONN_IDLE_TIME=30m`, `HEALTHCHECK_PERIOD=1m`) |
+| High traffic (>1000 req/s) | `STATICREG_DB_MAX_CONNS=100`, `STATICREG_DB_MIN_CONNS=10`. Coordinate with postgres `max_connections`. |
+| Many idle pods (k8s autoscaling) | `STATICREG_DB_MIN_CONNS=0`, `STATICREG_DB_MAX_CONN_IDLE_TIME=5m` so scaled-down pods do not hold open connections. |
+| Postgres behind a connection pooler (PgBouncer) | `STATICREG_DB_MAX_CONN_LIFETIME=15m` to encourage rebalancing across pooler backends. |
+
+Watch `/metrics/db` after tuning. If `empty_acquire_count` is climbing, the
+pool is undersized for the workload — increase `MAX_CONNS` (and verify
+postgres can accommodate the new ceiling).
+
+## Schema migration when upgrading from v0.7
+
+The bootstrap path in v0.7 created `container_pull_metrics` directly in
+`public`. After upgrading, that data is **not** auto-migrated to the new
+dedicated schema; the table simply stays where it is and StaticReg starts
+writing to the new location.
+
+To consolidate (run once, manually):
+
+```sql
+-- Inspect what's there first
+SELECT count(*) FROM public.container_pull_metrics;
+
+-- Copy across (preserves aggregation via the unique constraint)
+INSERT INTO staticreg.container_pull_metrics
+  (pull_date, repo_name, tag, digest, architecture, pull_count, created_at, updated_at)
+SELECT pull_date, repo_name, tag, digest, architecture, pull_count, created_at, updated_at
+FROM public.container_pull_metrics
+ON CONFLICT (pull_date, repo_name, tag, digest, architecture) DO UPDATE
+SET pull_count = staticreg.container_pull_metrics.pull_count + EXCLUDED.pull_count,
+    updated_at = NOW();
+
+-- Once verified
+DROP TABLE public.container_pull_metrics;
+```

--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -33,6 +33,22 @@ spec:
             limits:
               memory: "250Mi"
               cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8093
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz/db
+              port: 8093
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
           env:
             # Registry Configuration
             - name: STATICREG_REGISTRY_USER

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Seqera
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package server
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/seqeralabs/staticreg/pkg/observability/logger"
+	"github.com/seqeralabs/staticreg/pkg/webhook"
+)
+
+// livenessHandler always returns 200. The process being able to respond to HTTP
+// is the liveness signal; we deliberately do not check the database here so a
+// transient DB outage does not trigger a pod restart.
+func livenessHandler(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// dbReadinessHandler returns 200 when the pool is configured and a Ping
+// succeeds, 503 otherwise. Wired to a Kubernetes readiness probe so traffic is
+// drained from a pod that has lost its DB connection.
+func dbReadinessHandler(pool *pgxpool.Pool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if pool == nil {
+			c.JSON(http.StatusServiceUnavailable, ErrorResponse{Error: "database pool not configured"})
+			return
+		}
+		// Readiness probe must complete inside k8s' default 1s probe timeout.
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 750*time.Millisecond)
+		defer cancel()
+		if err := pool.Ping(ctx); err != nil {
+			// pgx error messages can echo connection details (host, user); keep
+			// them server-side and return a generic message to the probe client.
+			slog.Warn("readiness probe: database ping failed", logger.ErrAttr(err))
+			c.JSON(http.StatusServiceUnavailable, ErrorResponse{Error: "database unavailable"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	}
+}
+
+// dbMetricsHandler exposes pgxpool runtime stats as JSON. The same numbers can
+// be wrapped in a Prometheus collector later without changing the data source.
+func dbMetricsHandler(pool *pgxpool.Pool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if pool == nil {
+			c.JSON(http.StatusServiceUnavailable, ErrorResponse{Error: "database pool not configured"})
+			return
+		}
+		s := pool.Stat()
+		c.JSON(http.StatusOK, gin.H{
+			"acquired_conns":             s.AcquiredConns(),
+			"constructing_conns":         s.ConstructingConns(),
+			"idle_conns":                 s.IdleConns(),
+			"max_conns":                  s.MaxConns(),
+			"total_conns":                s.TotalConns(),
+			"new_conns_count":            s.NewConnsCount(),
+			"acquire_count":              s.AcquireCount(),
+			"acquire_duration_ns":        s.AcquireDuration().Nanoseconds(),
+			"empty_acquire_count":        s.EmptyAcquireCount(),
+			"canceled_acquire_count":     s.CanceledAcquireCount(),
+			"max_lifetime_destroy_count": s.MaxLifetimeDestroyCount(),
+			"max_idle_destroy_count":     s.MaxIdleDestroyCount(),
+		})
+	}
+}
+
+// webhookMetricsHandler exposes the batched webhook adapter's counters. Returns
+// 503 with an explanation when the adapter was constructed without a DB pool
+// (events are not being processed).
+func webhookMetricsHandler(adapter *webhook.BatchServiceAdapter) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if adapter == nil {
+			c.JSON(http.StatusServiceUnavailable, ErrorResponse{Error: "webhook adapter not configured"})
+			return
+		}
+		c.JSON(http.StatusOK, adapter.GetMetrics())
+	}
+}

--- a/pkg/server/health_integration_test.go
+++ b/pkg/server/health_integration_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Seqera
+
+//go:build integration
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/seqeralabs/staticreg/pkg/db"
+	"github.com/seqeralabs/staticreg/pkg/db/dbtest"
+)
+
+// Run with: go test -tags=integration ./pkg/server/...
+// Requires docker-compose postgres up.
+
+func TestDBReadinessHandler_HappyPath(t *testing.T) {
+	dbtest.SetEnv(t, "staticreg_health_test")
+	pool := db.InitPool()
+	if pool == nil {
+		t.Fatal("InitPool returned nil")
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DROP SCHEMA IF EXISTS staticreg_health_test CASCADE")
+		pool.Close()
+	})
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/healthz/db", dbReadinessHandler(pool))
+	r.GET("/metrics/db", dbMetricsHandler(pool))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/healthz/db", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("/healthz/db: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics/db", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("/metrics/db: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var stats map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &stats); err != nil {
+		t.Fatalf("decode metrics: %v", err)
+	}
+	for _, key := range []string{"acquired_conns", "idle_conns", "max_conns", "total_conns"} {
+		if _, ok := stats[key]; !ok {
+			t.Errorf("missing key %q in /metrics/db response: %v", key, stats)
+		}
+	}
+}

--- a/pkg/server/health_test.go
+++ b/pkg/server/health_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Seqera
+
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/seqeralabs/staticreg/pkg/webhook"
+)
+
+func newTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	return gin.New()
+}
+
+func TestLivenessHandler_AlwaysOK(t *testing.T) {
+	r := newTestRouter(t)
+	r.GET("/healthz", livenessHandler)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("body: got %v, want status=ok", body)
+	}
+}
+
+func TestDBReadinessHandler_NilPoolReturns503(t *testing.T) {
+	r := newTestRouter(t)
+	r.GET("/healthz/db", dbReadinessHandler(nil))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/healthz/db", nil))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503", w.Code)
+	}
+}
+
+func TestDBMetricsHandler_NilPoolReturns503(t *testing.T) {
+	r := newTestRouter(t)
+	r.GET("/metrics/db", dbMetricsHandler(nil))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics/db", nil))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503", w.Code)
+	}
+}
+
+func TestWebhookMetricsHandler_NilAdapterReturns503(t *testing.T) {
+	r := newTestRouter(t)
+	r.GET("/metrics/webhook", webhookMetricsHandler(nil))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics/webhook", nil))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503", w.Code)
+	}
+}
+
+func TestWebhookMetricsHandler_AdapterWithoutPoolReturnsZeroes(t *testing.T) {
+	// An adapter built with a nil pool still constructs successfully — no
+	// worker is started, but GetMetrics() should return the zeroed counters.
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	adapter := webhook.NewBatchServiceAdapter(log, nil)
+
+	r := newTestRouter(t)
+	r.GET("/metrics/webhook", webhookMetricsHandler(adapter))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics/webhook", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+	var body map[string]int64
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, key := range []string{"events_received", "events_dropped", "events_flushed", "batches_flushed", "current_queue_size"} {
+		if _, ok := body[key]; !ok {
+			t.Errorf("missing key %q in response", key)
+		}
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,6 +97,14 @@ func New(
 	r.Use(serverImpl.NotFoundHandler)
 	r.Use(serverImpl.InternalServerErrorHandler)
 
+	// Health and metrics endpoints are registered before ignoreUserAgentMiddleware
+	// so kubernetes probes and metric scrapers cannot be silenced by an operator's
+	// ignored-user-agent flag.
+	r.GET("/healthz", livenessHandler)
+	r.GET("/healthz/db", dbReadinessHandler(dbPool))
+	r.GET("/metrics/db", dbMetricsHandler(dbPool))
+	r.GET("/metrics/webhook", webhookMetricsHandler(whService))
+
 	staticRouter := r.Group("/static")
 	{
 		staticRouter.Use(cacheControlMiddleware())


### PR DESCRIPTION
## Summary

**PR 3 of 3** — final leg of the postgres enterprise hardening plan. Stacked on #65 → #64; please review/merge those first.

Adds four operational endpoints on the existing HTTP server, wires Kubernetes probes to them, and ships a postgres operations runbook.

| Endpoint | Purpose | Probe target |
|---|---|---|
| `GET /healthz` | Process liveness, no DB dependency. Returns 200 whenever the server can respond. | livenessProbe |
| `GET /healthz/db` | Pings the pool with a 750ms timeout. 200 / 503. | readinessProbe |
| `GET /metrics/db` | `pgxpool.Stat()` snapshot as JSON. | (scrape) |
| `GET /metrics/webhook` | `BatchServiceAdapter.GetMetrics()` snapshot. | (scrape) |

Routing is registered **before** `ignoreUserAgentMiddleware` so a probe client cannot be silenced by an operator's `--ignored-user-agent` flag. 503 responses reuse the existing `ErrorResponse` struct for consistency with the webhook handler.

`manifests/deployment.yml` gains `livenessProbe` (`/healthz`) and `readinessProbe` (`/healthz/db`) on the staticreg container.

## Documentation

- `docs/CONFIGURATION.md` — adds Health/Metrics endpoints reference and a Production Checklist.
- `docs/ARCHITECTURE.md` — refreshes the database section with schema-isolation, goose migrations, and the new health/observability endpoints.
- `docs/POSTGRES_OPERATIONS.md` — new runbook covering: schema layout, inspecting state via SQL/HTTP, adding new migrations, rolling back via the goose CLI image, pool-tuning guidance, and the v0.7 → v0.8 data-consolidation procedure operators may want to run after PR1 lands.

## Behavior change

Adding probes is opt-in for non-Kubernetes deployments (the YAML changes are inert if you don't use that manifest). For deployments using `manifests/deployment.yml` directly, k8s will start failing pods if `/healthz/db` returns 503 — this is the desired behavior (drains traffic from a pod whose DB connection is broken).

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` (unit) passes — new tests for all four handler nil-paths plus the no-pool webhook-adapter happy path
- [x] `go test -tags=integration ./pkg/server/...` passes against `docker compose up postgres` (verifies `/healthz/db` returns 200 and `/metrics/db` exposes the expected stat keys with a live pool)
- [x] End-to-end smoke test: built binary, started against compose postgres, hit all four endpoints with curl. Confirmed 200 status and correct JSON shapes:

  ```
  /healthz         → {"status":"ok"}
  /healthz/db      → {"status":"ok"}
  /metrics/db      → {"acquired_conns":0,"idle_conns":3,"max_conns":25,...}
  /metrics/webhook → {"events_received":0,"events_dropped":0,...}
  ```

- [ ] Reviewer to verify a staging k8s rollout: probe failure when postgres is killed, recovery after restoration; `/metrics/db` consumed by an existing scraper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)