### PR TITLE
fix(registry): skip index manifest entries with nil platform

### DIFF
--- a/pkg/registry/registry/registry.go
+++ b/pkg/registry/registry/registry.go
@@ -94,14 +94,16 @@ func (c *Registry) ImageInfo(ctx context.Context, image string, tag string) (reg
 	if err == nil {
 		indexManifest, err := index.IndexManifest()
 		if err == nil {
-			manifests := indexManifest.Manifests
-			if manifests != nil {
-				for _, manifest := range manifests {
-					arch := manifest.Platform.Architecture
-					if arch != "unknown" {
-						architectures = append(architectures, arch)
-						scanUrls = append(scanUrls, c.getScanUrl(ref.Context().Name(), manifest.Digest.String(), arch))
-					}
+			for _, manifest := range indexManifest.Manifests {
+				// Platform is optional in OCI index entries (e.g. attestation
+				// manifests) — dereferencing it unguarded crashes the sync loop.
+				if manifest.Platform == nil {
+					continue
+				}
+				arch := manifest.Platform.Architecture
+				if arch != "unknown" {
+					architectures = append(architectures, arch)
+					scanUrls = append(scanUrls, c.getScanUrl(ref.Context().Name(), manifest.Digest.String(), arch))
 				}
 			}
 		}


### PR DESCRIPTION
## Problem

Pods crash-loop on startup with:

```
panic: recovered from errgroup.Group: recovered from errgroup.Group: runtime error: invalid memory address or nil pointer dereference
```

## Root cause

`Registry.ImageInfo` iterates over OCI index manifest descriptors and dereferences `manifest.Platform` unconditionally. In go-containerregistry, `Descriptor.Platform` is a `*v1.Platform` and is nil whenever an index entry doesn't declare a platform (common for attestation/SBOM manifests). An image with such an index entry in `public.cr.seqera.io` causes the repository sync loop to panic, which propagates through the nested errgroups (hence the doubled "recovered from errgroup.Group") and kills the process.

## Fix

Skip descriptors with a nil platform before reading `Architecture`. Tags whose index entries all lack platforms fall through to the existing single-image `ConfigFile()` fallback. Also drops the redundant `manifests != nil` check (ranging over a nil slice is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)